### PR TITLE
build: update node and npm engines versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-	"name": "integration_discourse",
-	"version": "0.0.1",
-	"description": "Discourse integration",
-	"main": "index.js",
-	"directories": {
-		"test": "tests"
-	},
-	"scripts": {
-		"build": "NODE_ENV=production webpack --progress --config webpack.js",
-		"dev": "NODE_ENV=development webpack --progress --config webpack.js",
-		"watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
-		"lint": "eslint --ext .js,.vue src",
-		"lint:fix": "eslint --ext .js,.vue src --fix",
-		"stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
-		"stylelint:fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/nextcloud/integration_discourse"
-	},
-	"keywords": [
-		"discourse"
-	],
-	"author": "Julien Veyssier",
-	"license": "AGPL-3.0",
-	"bugs": {
-		"url": "https://github.com/nextcloud/integration_discourse/issues"
-	},
-	"homepage": "https://github.com/nextcloud/integration_discourse",
-	"browserslist": [
-		"extends @nextcloud/browserslist-config"
-	],
-	"engines": {
-		"node": "^20.0.0",
-		"npm": "^9.0.0 || ^10.0.0"
-	},
-	"dependencies": {
-		"@nextcloud/auth": "^2.4.0",
-		"@nextcloud/axios": "^2.5.1",
-		"@nextcloud/dialogs": "^6.1.1",
-		"@nextcloud/initial-state": "^2.2.0",
-		"@nextcloud/l10n": "^3.1.0",
-		"@nextcloud/moment": "^1.3.2",
-		"@nextcloud/password-confirmation": "^5.3.1",
-		"@nextcloud/router": "^3.0.1",
-		"@nextcloud/vue": "^8.22.0",
-		"vue": "^2.6.14",
-		"vue-material-design-icons": "^5.3.1"
-	},
-	"devDependencies": {
-		"@nextcloud/babel-config": "^1.2.0",
-		"@nextcloud/browserslist-config": "^3.0.1",
-		"@nextcloud/eslint-config": "^8.4.1",
-		"@nextcloud/stylelint-config": "^3.0.1",
-		"@nextcloud/webpack-vue-config": "^6.2.0",
-		"eslint-webpack-plugin": "^4.2.0",
-		"stylelint-webpack-plugin": "^5.0.1"
-	}
+  "name": "integration_discourse",
+  "version": "0.0.1",
+  "description": "Discourse integration",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "NODE_ENV=production webpack --progress --config webpack.js",
+    "dev": "NODE_ENV=development webpack --progress --config webpack.js",
+    "watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
+    "lint": "eslint --ext .js,.vue src",
+    "lint:fix": "eslint --ext .js,.vue src --fix",
+    "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
+    "stylelint:fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nextcloud/integration_discourse"
+  },
+  "keywords": [
+    "discourse"
+  ],
+  "author": "Julien Veyssier",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/nextcloud/integration_discourse/issues"
+  },
+  "homepage": "https://github.com/nextcloud/integration_discourse",
+  "browserslist": [
+    "extends @nextcloud/browserslist-config"
+  ],
+  "engines": {
+    "node": "^22.0.0",
+    "npm": "^10.5.0"
+  },
+  "dependencies": {
+    "@nextcloud/auth": "^2.4.0",
+    "@nextcloud/axios": "^2.5.1",
+    "@nextcloud/dialogs": "^6.1.1",
+    "@nextcloud/initial-state": "^2.2.0",
+    "@nextcloud/l10n": "^3.1.0",
+    "@nextcloud/moment": "^1.3.2",
+    "@nextcloud/password-confirmation": "^5.3.1",
+    "@nextcloud/router": "^3.0.1",
+    "@nextcloud/vue": "^8.22.0",
+    "vue": "^2.6.14",
+    "vue-material-design-icons": "^5.3.1"
+  },
+  "devDependencies": {
+    "@nextcloud/babel-config": "^1.2.0",
+    "@nextcloud/browserslist-config": "^3.0.1",
+    "@nextcloud/eslint-config": "^8.4.1",
+    "@nextcloud/stylelint-config": "^3.0.1",
+    "@nextcloud/webpack-vue-config": "^6.2.0",
+    "eslint-webpack-plugin": "^4.2.0",
+    "stylelint-webpack-plugin": "^5.0.1"
+  }
 }


### PR DESCRIPTION
Automated update of the npm and node engines versions according to [Nextcloud standards](https://github.com/nextcloud/standards/issues/5).