### PR TITLE
Prepare release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.4.0 - 2025-08-29
+
+### Added
+- search providers marked as external sources 
+
+### Changed
+- npm packages updated 
+- max NC version bumped to 32
+
 ## 2.3.0 - 2025-02-13
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <summary>Integration of Discourse forum and mailing list management system</summary>
     <description><![CDATA[Discourse integration provides a dashboard widget displaying your important notifications
     and the ability to find topics and posts with Nextcloud's unified search.]]></description>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Discourse</namespace>


### PR DESCRIPTION
### Added
- search providers marked as external sources 

### Changed
- npm packages updated 
- max NC version bumped to 32