### PR TITLE
Prepare v2.4.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/appinfo/info.xml    @andrey18106 @julien-nc
+/appinfo/info.xml    @julien-nc @janepie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.4.1 - 2025-09-01
+
+### Changed
+
+- Keep NC 31 as max supported NC version for integration_discourse v2.x.x
+
+### Fixed
+
+- Do not use `OCP\Search\IExternalProvider` before 32
+
 ## 2.4.0 - 2025-08-29
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <summary>Integration of Discourse forum and mailing list management system</summary>
     <description><![CDATA[Discourse integration provides a dashboard widget displaying your important notifications
     and the ability to find topics and posts with Nextcloud's unified search.]]></description>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Discourse</namespace>
@@ -22,7 +22,7 @@
     <bugs>https://github.com/nextcloud/integration_discourse/issues</bugs>
     <screenshot>https://github.com/nextcloud/integration_discourse/raw/main/img/screenshot1.jpg</screenshot>
     <dependencies>
-        <nextcloud min-version="28" max-version="32"/>
+        <nextcloud min-version="28" max-version="31"/>
     </dependencies>
     <settings>
         <personal>OCA\Discourse\Settings\Personal</personal>

--- a/lib/Search/DiscourseSearchPostsProvider.php
+++ b/lib/Search/DiscourseSearchPostsProvider.php
@@ -15,14 +15,13 @@ use OCP\IL10N;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\IUser;
-use OCP\Search\IExternalProvider;
 use OCP\Search\IProvider;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 use OCP\Security\ICrypto;
 
-class DiscourseSearchPostsProvider implements IProvider, IExternalProvider {
+class DiscourseSearchPostsProvider implements IProvider {
 
 	public function __construct(
 		private IAppManager $appManager,
@@ -147,9 +146,5 @@ class DiscourseSearchPostsProvider implements IProvider, IExternalProvider {
 		return isset($entry['username'])
 			? $this->urlGenerator->linkToRouteAbsolute('integration_discourse.discourseAPI.getDiscourseAvatar', ['username' => $entry['username']])
 			: $thumbnailUrl;
-	}
-
-	public function isExternalProvider(): bool {
-		return True;
 	}
 }

--- a/lib/Search/DiscourseSearchTopicsProvider.php
+++ b/lib/Search/DiscourseSearchTopicsProvider.php
@@ -15,14 +15,13 @@ use OCP\IL10N;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\IUser;
-use OCP\Search\IExternalProvider;
 use OCP\Search\IProvider;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 use OCP\Security\ICrypto;
 
-class DiscourseSearchTopicsProvider implements IProvider, IExternalProvider {
+class DiscourseSearchTopicsProvider implements IProvider {
 
 	public function __construct(
 		private IAppManager $appManager,
@@ -141,9 +140,5 @@ class DiscourseSearchTopicsProvider implements IProvider, IExternalProvider {
 		return $this->urlGenerator->getAbsoluteURL(
 			$this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg')
 		);
-	}
-
-	public function isExternalProvider(): bool {
-		return True;
 	}
 }


### PR DESCRIPTION
### Changed

- Keep NC 31 as max supported NC version for integration_discourse v2.x.x

### Fixed

- Do not use `OCP\Search\IExternalProvider` before 32