### PR TITLE
prepare 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 3.3.0 - 2026-07-21
+
+### Changed
+
+- Update dependencies, fix integration tests, and adjust CI PHP versions @julien-nc [#111](https://github.com/nextcloud/integration_discourse/pull/111)
+- Bump max NC version to 35 @julien-nc
+
 ## 3.2.0 - 2026-03-26
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <summary>Integration of Discourse forum and mailing list management system</summary>
     <description><![CDATA[Discourse integration provides a dashboard widget displaying your important notifications
     and the ability to find topics and posts with Nextcloud's unified search.]]></description>
-    <version>3.2.0</version>
+    <version>3.3.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Discourse</namespace>


### PR DESCRIPTION
### Changed

- Update dependencies, fix integration tests, and adjust CI PHP versions @julien-nc [#111](https://github.com/nextcloud/integration_discourse/pull/111)
- Bump max NC version to 35 @julien-nc